### PR TITLE
Remove unreachable targets and fix relex installation

### DIFF
--- a/octool_rpi.sh
+++ b/octool_rpi.sh
@@ -338,16 +338,34 @@ install_relex () {
     unzip jwnl14-rc2.zip jwnl14-rc2/jwnl.jar
     sudo mv $VERBOSE  jwnl14-rc2/jwnl.jar /usr/local/share/java/
     sudo chmod $VERBOSE  0644 /usr/local/share/java/jwnl.jar
+
+    export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF8
+    
+    #ANT_OPTS := -Dbuild.sysclasspath=only
+
+     # installing RelEx
+    git clone https://github.com/opencog/relex 
+    cd relex
+    if grep -q '^vagrant:' /etc/passwd; then
+        cd /home/vagrant/relex
+        sudo -u vagrant ant build
+    else
+     ant build
+    fi
+
+    sudo ant install
+
+
     
     #installing relex
-    wget https://github.com/Dagiopia/relex/archive/$RELEX_V.tar.gz
-    tar $VERBOSE -xf $RELEX_V.tar.gz 
-    cd relex-$RELEX_V
-    export CLASSPATH=/usr/local/share/java
-    ant build
-    sudo ant install
-    cd $HOME
-    rm $VERBOSE -rf /tmp/relex_temp_
+    #wget https://github.com/Dagiopia/relex/archive/$RELEX_V.tar.gz
+    #tar $VERBOSE -xf $RELEX_V.tar.gz 
+    #cd relex-$RELEX_V
+    #export CLASSPATH=/usr/local/share/java
+    #ant build
+    #sudo ant install
+    #cd $HOME
+    #rm $VERBOSE -rf /tmp/relex_temp_
 }
 
 install_bdwgc_deb () {

--- a/octool_rpi.sh
+++ b/octool_rpi.sh
@@ -418,9 +418,9 @@ if [ $INSTALL_DEPS ] ; then
 			sudo apt-get install -y $APT_ARGS libboost1.62-dev
 		else
 			#install boost 1.60
-			wget http://144.76.153.5/opencog/libboost-1.60-all-dev-1_armhf.deb
-			sudo dpkg -i libboost-1.60-all-dev-1_armhf.deb
-			rm libboost-1.60-all-dev-1_armhf.deb
+			wget http://144.76.153.5/opencog/libboost-1.55-all-dev-1_armhf.deb
+			sudo dpkg -i libboost-1.55-all-dev-1_armhf.deb
+			rm libboost-1.55-all-dev-1_armhf.deb
 		fi
 	#	install_bdwgc # install bdwgc from source
 	#	install_guile # install guile  from source

--- a/octool_rpi.sh
+++ b/octool_rpi.sh
@@ -418,9 +418,10 @@ if [ $INSTALL_DEPS ] ; then
 			sudo apt-get install -y $APT_ARGS libboost1.62-dev
 		else
 			#install boost 1.60
-			wget http://144.76.153.5/opencog/libboost-1.55-all-dev-1_armhf.deb
-			sudo dpkg -i libboost-1.55-all-dev-1_armhf.deb
-			rm libboost-1.55-all-dev-1_armhf.deb
+			#wget http://144.76.153.5/opencog/libboost-1.55-all-dev-1_armhf.deb
+			#sudo dpkg -i libboost-1.55-all-dev-1_armhf.deb
+			#rm libboost-1.55-all-dev-1_armhf.deb
+                        sudo apt-get install -y $APT_ARGS libboost1.55-all-dev
 		fi
 	#	install_bdwgc # install bdwgc from source
 	#	install_guile # install guile  from source


### PR DESCRIPTION

- Change the libboost version to 1.55 

- Install libboost by apt-get instead of dpkg because the site to download the .deb file does not exist

- Modify the relex installation part by solving the error "Unmappable character for encoding ASCII"

